### PR TITLE
Call the volume methods to resolve a TypeError

### DIFF
--- a/OBDHandler.py
+++ b/OBDHandler.py
@@ -43,10 +43,10 @@ class OBDHandler():
     
     def get_volumes(self):
         volumes = [
-            self.get_bass_volume,
-            self.get_drums_volume,
-            self.get_other_volume,
-            self.get_vocals_volume
+            self.get_bass_volume(),
+            self.get_drums_volume(),
+            self.get_other_volume(),
+            self.get_vocals_volume()
         ]
         return volumes
 


### PR DESCRIPTION
Just went for a spin.. pretty cool.  Initially I was getting this error with python 3.9 & 3.12 on a mac:

    TypeError: must be real number, not method

All good after adding the parentheses to call the methods.